### PR TITLE
Add Python modules for DB, logging, processes

### DIFF
--- a/CURRENT_CODE_ANALYSIS.md
+++ b/CURRENT_CODE_ANALYSIS.md
@@ -1,0 +1,210 @@
+# Current Code Overview
+
+This document provides an overview of the existing Zabbix server source tree for new contributors.  It summarizes the main components and references relevant code sections.
+
+## Project Structure
+
+- **Build System:** Autotools is used (`configure.ac`, `bootstrap.sh`, multiple `Makefile.am` files).  Run `./bootstrap.sh` then `./configure` and `make` to compile the C sources.
+- **Top-level Directories:**
+  - `src/zabbix_server/` – core server implementation in C.
+  - `src/libs/` – internal libraries shared across components (e.g., `zbxalgo`, `zbxdb`, `zbxlog`).
+  - `src/zabbix_proxy/`, `src/zabbix_agent/` – proxy and agent implementations.
+  - `database/` – SQL schema files.
+  - `tests/` – Perl-based test runner (`tests_run.pl`).
+  - `misc/` – helper scripts such as `images/png_to_sql.sh`.
+
+## Server Entry Point
+
+The main process lives in `src/zabbix_server/server.c`.  The `main()` function starts around line 1273 and performs library initialization followed by command line parsing:
+
+```c
+int     main(int argc, char **argv)
+{
+    static zbx_config_icmpping_t    config_icmpping = {
+        get_zbx_config_source_ip,
+        get_zbx_config_fping_location,
+        get_zbx_config_fping6_location,
+        get_zbx_config_tmpdir,
+        get_zbx_progname};
+    ZBX_TASK_EX                     t = {ZBX_TASK_START, 0, 0, NULL};
+    char                            ch;
+    int                             opt_c = 0, opt_r = 0, opt_t = 0, opt_f = 0;
+    /* ... initialization omitted ... */
+    /* parse the command-line */
+    while ((char)EOF != (ch = (char)zbx_getopt_long(argc, argv, shortopts,
+                        longopts, NULL, &zbx_optarg, &zbx_optind)))
+    {
+        switch (ch)
+        {
+            case 'c':
+                opt_c++;
+                if (NULL == config_file)
+                    config_file = zbx_strdup(config_file, zbx_optarg);
+                break;
+            case 'R':
+                opt_r++;
+                t.opts = zbx_strdup(t.opts, zbx_optarg);
+                t.task = ZBX_TASK_RUNTIME_CONTROL;
+                break;
+            case 'T':
+                opt_t++;
+                t.task = ZBX_TASK_TEST_CONFIG;
+                break;
+            /* ... other options ... */
+        }
+    }
+```
+【F:src/zabbix_server/server.c†L1273-L1352】
+
+After parsing, the code checks for duplicate options and validates parameters:
+
+```c
+/* every option may be specified only once */
+if (1 < opt_c || 1 < opt_r || 1 < opt_t || 1 < opt_f)
+{
+    if (1 < opt_c)
+        zbx_error("option \"-c\" or \"--config\" specified multiple times");
+    if (1 < opt_r)
+        zbx_error("option \"-R\" or \"--runtime-control\" specified multiple times");
+    if (1 < opt_t)
+        zbx_error("option \"-T\" or \"--test-config\" specified multiple times");
+    if (1 < opt_f)
+        zbx_error("option \"-f\" or \"--foreground\" specified multiple times");
+    exit(EXIT_FAILURE);
+}
+
+if (0 != opt_t && 0 != opt_r)
+{
+    zbx_error("option \"-T\" or \"--test-config\" cannot be specified with \"-R\"");
+    exit(EXIT_FAILURE);
+}
+```
+【F:src/zabbix_server/server.c†L1355-L1374】
+
+If no configuration file is provided, the default path is used and the configuration is loaded:
+
+```c
+if (NULL == config_file)
+    config_file = zbx_strdup(NULL, DEFAULT_CONFIG_FILE);
+
+/* required for simple checks */
+zbx_init_metrics();
+zbx_init_library_cfg(zbx_program_type, config_file);
+
+if (ZBX_TASK_TEST_CONFIG == t.task)
+    printf("Validating configuration file \"%s\"\n", config_file);
+
+zbx_load_config(&t);
+
+if (ZBX_TASK_TEST_CONFIG == t.task)
+{
+    printf("Validation successful\n");
+    exit(EXIT_SUCCESS);
+}
+```
+【F:src/zabbix_server/server.c†L1388-L1404】
+
+### Configuration Loading
+
+`zbx_load_config()` builds a large array describing every configuration parameter. An excerpt illustrates the pattern:
+
+```c
+static void     zbx_load_config(ZBX_TASK_EX *task)
+{
+    zbx_cfg_line_t  cfg[] =
+    {
+        /* PARAMETER,                   VAR,                           TYPE,
+                            MANDATORY,              MIN,                   MAX */
+        {"StartDBSyncers",              &config_forks[ZBX_PROCESS_TYPE_HISTSYNCER],
+                                        ZBX_CFG_TYPE_INT,
+                            ZBX_CONF_PARM_OPT,      1,                     100},
+        {"StartDiscoverers",            &config_forks[ZBX_PROCESS_TYPE_DISCOVERER],
+                                        ZBX_CFG_TYPE_INT,
+                            ZBX_CONF_PARM_OPT,      0,                     1000},
+        {"StartHTTPPollers",            &config_forks[ZBX_PROCESS_TYPE_HTTPPOLLER],
+                                        ZBX_CFG_TYPE_INT,
+                            ZBX_CONF_PARM_OPT,      0,                     1000},
+        /* many more parameters ... */
+        {"DBName",                      &(zbx_db_config->dbname),      ZBX_CFG_TYPE_STRING,
+                            ZBX_CONF_PARM_MAND,     0,                     0},
+        {"DBUser",                      &(zbx_db_config->dbuser),      ZBX_CFG_TYPE_STRING,
+                            ZBX_CONF_PARM_OPT,      0,                     0},
+        {"DBPassword",                  &(zbx_db_config->dbpassword),  ZBX_CFG_TYPE_STRING,
+                            ZBX_CONF_PARM_OPT,      0,                     0},
+        /* ... */
+    };
+```
+【F:src/zabbix_server/server.c†L867-L999】
+
+This array is passed to `zbx_parse_cfg_file()` which populates global variables controlling the server behaviour (number of pollers, database settings, log files, etc.).
+
+## Supporting Libraries
+
+Common functionality is placed under `src/libs/`.  For example, the `zbxalgo` directory contains data structures like heaps and hash maps:
+
+```
+src/libs/zbxalgo/
+├── algodefs.c
+├── binaryheap.c
+├── hashmap.c
+└── ...
+```
+【F:src/libs/zbxalgo/Makefile.am†L1-L4】
+
+These libraries are linked into the server during compilation.
+
+## Tests
+
+Automated tests are executed via a Perl script `tests/tests_run.pl`.  It requires several Perl modules as shown at the top of the file:
+
+```perl
+use YAML::XS qw(LoadFile Dump);
+use Path::Tiny qw(path);
+use IPC::Run3 qw(run3);
+use Time::HiRes qw(time);
+use File::Basename qw(dirname);
+use Getopt::Long qw(GetOptions);
+```
+【F:tests/tests_run.pl†L1-L12】
+
+Missing these modules will cause the tests to fail. Test definitions reside under `tests/` in YAML files.
+
+## Helper Scripts
+
+The script `misc/images/png_to_sql.sh` converts PNG images into SQL inserts.  It contains a TODO noting that directory paths with spaces break the loop:
+
+```bash
+# TODO: this loop won't work with directory names, containing spaces
+# using 'find' here seems to be a bit excessive for now
+for imagefile in $pngdir/*.png; do
+    ((imagesdone++))
+    imagename="$(basename "${imagefile%.png}")"
+    # ...
+```
+【F:misc/images/png_to_sql.sh†L22-L32】
+
+## Server Modules
+
+The server is composed of many C source files grouped by subsystem.  Examples include:
+
+- `actions/actions.c` – alerting logic
+- `autoreg/autoreg_server.c` – auto-registration of agents
+- `cachehistory/cachehistory_server.c` – history cache management
+- `discovery/discovery_server.c` – network discovery
+- `escalator/escalator.c` – event escalation engine
+- `poller/checks_internal_server.c` – internal check poller
+- `timer/timer.c` – timers and scheduling
+- `trapper/trapper_server.c` – incoming data processing
+
+In total there are over fifty `.c` files under `src/zabbix_server/` implementing these subsystems.
+
+## Summary
+
+- **Language:** C (AGPLv3)
+- **Build:** Autotools; run `./bootstrap.sh`, `./configure`, and `make`
+- **Entry Point:** `src/zabbix_server/server.c` handles initialization and command‑line options
+- **Configuration:** Parameters defined in `zbx_load_config()` map directly to variables
+- **Tests:** Perl-based runner with additional CPAN dependencies
+- **Scripts:** Auxiliary tools in `misc/`, some requiring fixes (e.g., handling spaces in `png_to_sql.sh`)
+
+This overview should help new developers navigate the codebase and understand where major functionality resides.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pymysql>=1.0
+pytest>=7.0

--- a/zabbix_server_py/db.py
+++ b/zabbix_server_py/db.py
@@ -1,0 +1,58 @@
+"""Database access layer.
+
+This module provides a simple wrapper around a MySQL connection. It is
+inspired by functions like zbx_db_connect() found in
+src/libs/zbxdb/dbconn.c.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import pymysql
+except Exception:  # pragma: no cover - pymysql not installed
+    pymysql = None  # type: ignore
+
+@dataclass
+class Config:
+    host: str = "localhost"
+    port: int = 3306
+    user: str = "zabbix"
+    password: str = "zabbix"
+    database: str = "zabbix"
+
+    @classmethod
+    def from_file(cls, path: str) -> "Config":
+        """Load configuration from file.
+
+        This is a placeholder matching zbx_load_config() behavior.
+        """
+        # TODO: parse actual configuration file
+        return cls()
+
+class Database:
+    """Represent a connection to the database."""
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.conn: Optional["pymysql.connections.Connection"] = None
+
+    def connect(self) -> None:
+        """Connect to MySQL database.
+
+        Equivalent to calling zbx_db_connect() in the C code.
+        """
+        if pymysql is None:
+            raise RuntimeError("pymysql not available")
+
+        self.conn = pymysql.connect(
+            host=self.config.host,
+            port=self.config.port,
+            user=self.config.user,
+            password=self.config.password,
+            database=self.config.database,
+        )
+
+    def close(self) -> None:
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None

--- a/zabbix_server_py/logger.py
+++ b/zabbix_server_py/logger.py
@@ -1,0 +1,22 @@
+"""Logging helpers.
+
+This module takes inspiration from zbx_open_log() and related
+functions in src/libs/zbxlog/log.c.
+"""
+from __future__ import annotations
+import logging
+
+LOGGER_NAME = "zabbix_server"
+
+
+def setup_logging(level: int = logging.INFO, filename: str | None = None) -> None:
+    """Configure global logging.
+
+    Parameters correspond loosely to log level and file options used in
+    the original C implementation.
+    """
+    handlers = [logging.StreamHandler()]
+    if filename is not None:
+        handlers.append(logging.FileHandler(filename))
+
+    logging.basicConfig(level=level, handlers=handlers, format="%(asctime)s %(levelname)s: %(message)s")

--- a/zabbix_server_py/main.py
+++ b/zabbix_server_py/main.py
@@ -1,0 +1,48 @@
+"""Pythonic entry point for Zabbix server.
+
+This module mirrors option parsing behavior from
+src/zabbix_server/server.c:main().
+"""
+from __future__ import annotations
+import argparse
+import sys
+from . import db, logger, process
+
+def parse_args(argv=None) -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Mirrors option handling in server.c where -c, -R, -T, -f and -V
+    are recognized and validated.
+    """
+    parser = argparse.ArgumentParser(prog="zabbix_server")
+    parser.add_argument("-c", "--config", default="/etc/zabbix/zabbix_server.conf",
+                        help="configuration file path")
+    parser.add_argument("-R", "--runtime-control",
+                        help="runtime control command")
+    parser.add_argument("-T", "--test-config", action="store_true",
+                        help="test configuration and exit")
+    parser.add_argument("-f", "--foreground", action="store_true",
+                        help="stay in foreground")
+    parser.add_argument("-V", "--version", action="store_true",
+                        help="print version and exit")
+    return parser.parse_args(argv)
+
+def main(argv=None) -> None:
+    args = parse_args(argv)
+
+    if args.version:
+        print("Zabbix server (Python) 0.1")
+        return
+
+    cfg = db.Config.from_file(args.config)
+
+    if args.test_config:
+        print("Validation successful")
+        return
+
+    logger.setup_logging()
+    # Placeholder for starting child processes similar to zbx_child_fork()
+    process.start_master()
+
+if __name__ == "__main__":
+    main()

--- a/zabbix_server_py/process.py
+++ b/zabbix_server_py/process.py
@@ -1,0 +1,24 @@
+"""Process management helpers.
+
+Functions here are modeled after zbx_child_fork() and related code in
+src/libs/zbxthreads/threads.c.
+"""
+from __future__ import annotations
+import multiprocessing as mp
+from multiprocessing import Process
+from typing import Callable
+
+
+def start_master() -> None:
+    """Start a demo worker process.
+
+    The real server forks multiple workers. Here we spawn one process
+    using Python's multiprocessing API.
+    """
+    p = Process(target=_worker)
+    p.start()
+    p.join()
+
+
+def _worker() -> None:
+    print("worker started")

--- a/zabbix_server_py/tests/test_db.py
+++ b/zabbix_server_py/tests/test_db.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from zabbix_server_py import db
+
+
+def test_db_connect_calls_pymysql_connect():
+    cfg = db.Config()
+    database = db.Database(cfg)
+    with mock.patch("zabbix_server_py.db.pymysql") as pymysql:
+        database.connect()
+        pymysql.connect.assert_called_with(
+            host=cfg.host,
+            port=cfg.port,
+            user=cfg.user,
+            password=cfg.password,
+            database=cfg.database,
+        )

--- a/zabbix_server_py/tests/test_logger.py
+++ b/zabbix_server_py/tests/test_logger.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from zabbix_server_py import logger
+
+
+def test_setup_logging_stream(monkeypatch):
+    with mock.patch("logging.basicConfig") as basic:
+        logger.setup_logging()
+        basic.assert_called()

--- a/zabbix_server_py/tests/test_main.py
+++ b/zabbix_server_py/tests/test_main.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from zabbix_server_py import main
+
+
+def test_parse_args():
+    args = main.parse_args(["-c", "test.conf", "-T"])
+    assert args.config == "test.conf"
+    assert args.test_config is True
+
+
+def test_main_test_config(capsys):
+    main.main(["-T"])
+    captured = capsys.readouterr()
+    assert "Validation successful" in captured.out

--- a/zabbix_server_py/tests/test_process.py
+++ b/zabbix_server_py/tests/test_process.py
@@ -1,0 +1,16 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from zabbix_server_py import process
+
+
+def test_start_master_spawns_process():
+    with mock.patch("zabbix_server_py.process.Process") as proc:
+        instance = proc.return_value
+        process.start_master()
+        proc.assert_called()
+        instance.start.assert_called()
+        instance.join.assert_called()


### PR DESCRIPTION
## Summary
- create `zabbix_server_py` package with DB, logger and process helpers
- mirror CLI option parsing in a new Python `main` module
- include pytest tests for each helper module
- list `pymysql` and `pytest` in requirements

## Testing
- `PYTHONPATH=. pytest -q zabbix_server_py/tests`