### PR TITLE
Add default CLI config option

### DIFF
--- a/zabbix_server_py/main.py
+++ b/zabbix_server_py/main.py
@@ -12,7 +12,12 @@ DEFAULT_CONFIG = Path("/etc/zabbix/zabbix_server.conf")
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="zabbix_server")
-    parser.add_argument("-c", "--config", help="path to config file")
+    parser.add_argument(
+        "-c",
+        "--config",
+        default=str(DEFAULT_CONFIG),
+        help="path to config file",
+    )
     parser.add_argument("-R", "--runtime-control", help="runtime control command")
     parser.add_argument("-T", "--test-config", action="store_true", help="test configuration and exit")
     parser.add_argument("-f", "--foreground", action="store_true", help="run in foreground")
@@ -32,10 +37,7 @@ def main(argv: list[str] | None = None) -> int:
         print("Zabbix Server (Python rewrite)")
         return 0
 
-    if args.config:
-        config_path = Path(args.config)
-    else:
-        config_path = DEFAULT_CONFIG
+    config_path = Path(args.config)
 
     # load configuration (placeholder)
     load_config(config_path)

--- a/zabbix_server_py/tests/test_main.py
+++ b/zabbix_server_py/tests/test_main.py
@@ -3,13 +3,27 @@ from zabbix_server_py.main import parse_args, main
 
 def test_parse_args_defaults():
     args = parse_args([])
-    assert args.config is None
+    assert args.config == "/etc/zabbix/zabbix_server.conf"
     assert args.test_config is False
     assert args.foreground is False
+
+
+def test_parse_args_all_options():
+    args = parse_args(["-c", "my.conf", "-R", "reload", "-f"])
+    assert args.config == "my.conf"
+    assert args.runtime_control == "reload"
+    assert args.foreground is True
 
 
 def test_test_config_mode(capsys):
     exit_code = main(["-T", "-c", "sample.conf"])
     captured = capsys.readouterr()
     assert "Validation successful" in captured.out
+    assert exit_code == 0
+
+
+def test_version_mode(capsys):
+    exit_code = main(["-V"])
+    captured = capsys.readouterr()
+    assert "Zabbix Server" in captured.out
     assert exit_code == 0


### PR DESCRIPTION
## Summary
- set `--config` default path for zabbix_server_py CLI
- update unit tests for new defaults and additional options

## Testing
- `pytest -q zabbix_server_py/tests/test_main.py`