### PR TITLE
Port audit utilities to Python

### DIFF
--- a/zabbix_server_py/audit/__init__.py
+++ b/zabbix_server_py/audit/__init__.py
@@ -1,0 +1,52 @@
+"""Simple audit logging utilities for the Python server rewrite."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class AuditEntry:
+    """Single audit log entry."""
+
+    resource: str
+    action: str
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+class AuditLogger:
+    """Collects audit log entries in memory."""
+
+    def __init__(self) -> None:
+        self.entries: List[AuditEntry] = []
+
+    def log(self, resource: str, action: str, **data: Any) -> None:
+        entry = AuditEntry(resource=resource, action=action, data=data)
+        self.entries.append(entry)
+
+
+# Configuration reload auditing -------------------------------------------------
+
+def proxy_config_reload(logger: AuditLogger, proxy_id: int, name: str) -> None:
+    """Record that a proxy configuration was reloaded."""
+    logger.log("proxy", "config_reload", id=proxy_id, name=name)
+
+
+# Settings auditing -------------------------------------------------------------
+
+def settings_create_entry(logger: AuditLogger, action: str) -> None:
+    """Create audit entry for settings action."""
+    logger.log("settings", action)
+
+
+def settings_update_field_str(
+    logger: AuditLogger, key: str, old_value: str | None, new_value: str | None
+) -> None:
+    """Record a change of a string configuration field."""
+    logger.log(
+        "settings",
+        "update",
+        key=key,
+        old_value=old_value,
+        new_value=new_value,
+    )

--- a/zabbix_server_py/tests/test_audit.py
+++ b/zabbix_server_py/tests/test_audit.py
@@ -1,0 +1,30 @@
+from zabbix_server_py.audit import (
+    AuditLogger,
+    proxy_config_reload,
+    settings_create_entry,
+    settings_update_field_str,
+)
+
+
+def test_proxy_config_reload():
+    logger = AuditLogger()
+    proxy_config_reload(logger, 42, "proxy1")
+    assert len(logger.entries) == 1
+    entry = logger.entries[0]
+    assert entry.resource == "proxy"
+    assert entry.action == "config_reload"
+    assert entry.data["id"] == 42
+    assert entry.data["name"] == "proxy1"
+
+
+def test_settings_audit():
+    logger = AuditLogger()
+    settings_create_entry(logger, "update")
+    settings_update_field_str(logger, "log_level", "INFO", "DEBUG")
+    assert len(logger.entries) == 2
+    create_entry, update_entry = logger.entries
+    assert create_entry.resource == "settings"
+    assert create_entry.action == "update"
+    assert update_entry.data["key"] == "log_level"
+    assert update_entry.data["old_value"] == "INFO"
+    assert update_entry.data["new_value"] == "DEBUG"


### PR DESCRIPTION
## Summary
- implement basic audit logger under `zabbix_server_py/audit`
- add helpers for proxy config reload and settings audits
- test audit log entry creation

## Testing
- `pytest -q`