### PR TITLE
Add Python autoreg server logic

### DIFF
--- a/zabbix_server_py/__init__.py
+++ b/zabbix_server_py/__init__.py
@@ -1,0 +1,1 @@
+from .autoreg.autoreg_server import AutoRegServer

--- a/zabbix_server_py/autoreg/autoreg_server.py
+++ b/zabbix_server_py/autoreg/autoreg_server.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+import sqlite3
+
+
+@dataclass
+class AutoRegHost:
+    """Representation of an autoregistered host."""
+
+    host: str
+    ip: str
+    dns: str
+    port: int
+    connection_type: int
+    host_metadata: str
+    flag: int
+    now: int
+    proxyid: Optional[int] = None
+    autoreg_hostid: Optional[int] = None
+    hostid: Optional[int] = None
+
+
+class AutoRegServer:
+    """Simplified autoregistration handler using SQLite."""
+
+    def __init__(self, db_path: str | Path = ":memory:") -> None:
+        self.db_path = str(db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self._setup_schema()
+        self._hosts: List[AutoRegHost] = []
+
+    def _setup_schema(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS autoreg_host (
+                    autoreg_hostid INTEGER PRIMARY KEY AUTOINCREMENT,
+                    proxyid INTEGER,
+                    host TEXT NOT NULL,
+                    listen_ip TEXT NOT NULL,
+                    listen_port INTEGER NOT NULL,
+                    listen_dns TEXT NOT NULL,
+                    host_metadata TEXT NOT NULL,
+                    flags INTEGER NOT NULL,
+                    tls_accepted INTEGER NOT NULL DEFAULT 1
+                )
+                """
+            )
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def prepare_host(
+        self,
+        host: str,
+        ip: str,
+        dns: str,
+        port: int,
+        connection_type: int,
+        host_metadata: str,
+        flag: int,
+        now: int,
+    ) -> None:
+        """Prepare host information for flush."""
+        # remove existing entry with the same host name if present
+        self._hosts = [h for h in self._hosts if h.host != host]
+        self._hosts.append(
+            AutoRegHost(
+                host=host,
+                ip=ip,
+                dns=dns,
+                port=port,
+                connection_type=connection_type,
+                host_metadata=host_metadata,
+                flag=flag,
+                now=now,
+            )
+        )
+
+    def flush_hosts(self, proxyid: Optional[int] = None) -> List[AutoRegHost]:
+        """Insert or update prepared hosts in the database."""
+        updated: List[AutoRegHost] = []
+
+        for h in self._hosts:
+            row = self.conn.execute(
+                "SELECT autoreg_hostid FROM autoreg_host WHERE host=?",
+                (h.host,),
+            ).fetchone()
+            if row:
+                h.autoreg_hostid = row["autoreg_hostid"]
+                with self.conn:
+                    self.conn.execute(
+                        """
+                        UPDATE autoreg_host
+                           SET listen_ip=?, listen_dns=?, listen_port=?,
+                               host_metadata=?, flags=?, proxyid=?
+                         WHERE autoreg_hostid=?
+                        """,
+                        (
+                            h.ip,
+                            h.dns,
+                            h.port,
+                            h.host_metadata,
+                            h.flag,
+                            proxyid,
+                            h.autoreg_hostid,
+                        ),
+                    )
+            else:
+                with self.conn:
+                    cur = self.conn.execute(
+                        """
+                        INSERT INTO autoreg_host (
+                            proxyid, host, listen_ip, listen_port, listen_dns,
+                            host_metadata, flags, tls_accepted
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+                        """,
+                        (
+                            proxyid,
+                            h.host,
+                            h.ip,
+                            h.port,
+                            h.dns,
+                            h.host_metadata,
+                            h.flag,
+                        ),
+                    )
+                    h.autoreg_hostid = cur.lastrowid
+            updated.append(h)
+
+        self._hosts.clear()
+        return updated
+
+    def update_host(
+        self,
+        host: str,
+        ip: str,
+        dns: str,
+        port: int,
+        connection_type: int,
+        host_metadata: str,
+        flag: int,
+        now: int,
+        proxyid: Optional[int] = None,
+    ) -> AutoRegHost:
+        """Register single host (prepare and flush)."""
+        self.prepare_host(host, ip, dns, port, connection_type, host_metadata, flag, now)
+        hosts = self.flush_hosts(proxyid=proxyid)
+        return hosts[0]

--- a/zabbix_server_py/tests/test_autoreg_server.py
+++ b/zabbix_server_py/tests/test_autoreg_server.py
@@ -1,0 +1,63 @@
+from zabbix_server_py.autoreg.autoreg_server import AutoRegServer
+
+
+def test_register_new_host(tmp_path):
+    db_file = tmp_path / "autoreg.db"
+    server = AutoRegServer(db_file)
+    host = server.update_host(
+        host="agent1",
+        ip="192.0.2.1",
+        dns="agent1.example",
+        port=10050,
+        connection_type=0,
+        host_metadata="",
+        flag=0,
+        now=0,
+    )
+    row = server.conn.execute("SELECT host, listen_ip FROM autoreg_host WHERE autoreg_hostid=?", (host.autoreg_hostid,)).fetchone()
+    assert row["host"] == "agent1"
+    assert row["listen_ip"] == "192.0.2.1"
+    server.close()
+
+
+def test_register_existing_host_updates(tmp_path):
+    db_file = tmp_path / "autoreg.db"
+    server = AutoRegServer(db_file)
+    server.update_host(
+        host="agent2",
+        ip="192.0.2.2",
+        dns="agent2.example",
+        port=10050,
+        connection_type=0,
+        host_metadata="",
+        flag=0,
+        now=0,
+    )
+    server.update_host(
+        host="agent2",
+        ip="192.0.2.99",
+        dns="agent2.example",
+        port=10051,
+        connection_type=0,
+        host_metadata="",
+        flag=1,
+        now=0,
+    )
+    row = server.conn.execute("SELECT listen_ip, listen_port, flags FROM autoreg_host WHERE host='agent2'").fetchone()
+    assert row["listen_ip"] == "192.0.2.99"
+    assert row["listen_port"] == 10051
+    assert row["flags"] == 1
+    server.close()
+
+
+def test_prepare_and_flush_multiple_hosts(tmp_path):
+    db_file = tmp_path / "autoreg.db"
+    server = AutoRegServer(db_file)
+    server.prepare_host("h1", "10.0.0.1", "h1", 10050, 0, "", 0, 0)
+    server.prepare_host("h2", "10.0.0.2", "h2", 10050, 0, "", 0, 0)
+    hosts = server.flush_hosts()
+    assert len(hosts) == 2
+    rows = server.conn.execute("SELECT COUNT(*) as c FROM autoreg_host").fetchone()
+    assert rows["c"] == 2
+    server.close()
+


### PR DESCRIPTION
## Summary
- implement simplified autoregistration logic using sqlite
- expose `AutoRegServer` in package
- test registration behaviour

## Testing
- `pytest -q`