### PR TITLE
Add Python cachehistory module with tests

### DIFF
--- a/zabbix_server_py/cachehistory/__init__.py
+++ b/zabbix_server_py/cachehistory/__init__.py
@@ -1,0 +1,6 @@
+"""Caching and trigger evaluation utilities."""
+
+from .cache import HistoryCache
+from .trigger import Trigger
+
+__all__ = ["HistoryCache", "Trigger"]

--- a/zabbix_server_py/cachehistory/cache.py
+++ b/zabbix_server_py/cachehistory/cache.py
@@ -1,0 +1,44 @@
+"""Simplified history cache implementation.
+
+This module loosely translates parts of ``cachehistory_server.c`` to Python.
+It provides minimal in-memory caching functionality for storing history data.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple
+
+
+class HistoryCache:
+    """In-memory store for item history.
+
+    This class implements just enough logic for unit testing.  It loosely
+    corresponds to the history processing routines inside
+    ``cachehistory_server.c`` such as ``dc_add_history`` and
+    ``recalculate_triggers``.
+    """
+
+    def __init__(self) -> None:
+        self._data: Dict[int, List[Tuple[int, Any]]] = defaultdict(list)
+
+    def add(self, itemid: int, value: Any, timestamp: int | None = None) -> None:
+        """Store a value for the given item.
+
+        Parameters mirror the structures filled in ``dc_history_set_value`` in
+        the original C implementation.
+        """
+        if timestamp is None:
+            timestamp = int(time.time())
+        self._data[itemid].append((timestamp, value))
+
+    def get_last(self, itemid: int) -> Any:
+        """Return the most recent value for *itemid* or ``None``."""
+        if not self._data[itemid]:
+            return None
+        return self._data[itemid][-1][1]
+
+    def get_history(self, itemid: int) -> List[Tuple[int, Any]]:
+        """Return the full history list for *itemid*."""
+        return list(self._data[itemid])

--- a/zabbix_server_py/cachehistory/trigger.py
+++ b/zabbix_server_py/cachehistory/trigger.py
@@ -1,0 +1,34 @@
+"""Simplified trigger evaluation routines.
+
+This module is a high-level rewrite of parts of ``trigger_eval.c``.  Only a
+very small subset of functionality is provided for unit testing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .cache import HistoryCache
+
+
+@dataclass
+class Trigger:
+    """Representation of a trigger expression."""
+
+    triggerid: int
+    expression: str
+
+    def evaluate(self, cache: HistoryCache) -> bool:
+        """Evaluate the trigger expression using *cache*.
+
+        The expression is executed as a Python expression with ``cache`` in the
+        local namespace.  This roughly mirrors the evaluation performed in
+        ``evaluate_item_functions`` from ``trigger_eval.c`` but without the
+        complex parsing and error handling.
+        """
+
+        try:
+            return bool(eval(self.expression, {}, {"cache": cache}))
+        except Exception:
+            return False

--- a/zabbix_server_py/tests/test_cachehistory.py
+++ b/zabbix_server_py/tests/test_cachehistory.py
@@ -1,0 +1,10 @@
+from zabbix_server_py.cachehistory.cache import HistoryCache
+
+
+def test_store_and_retrieve():
+    cache = HistoryCache()
+    cache.add(1, 100, timestamp=1)
+    cache.add(1, 200, timestamp=2)
+
+    assert cache.get_last(1) == 200
+    assert cache.get_history(1) == [(1, 100), (2, 200)]

--- a/zabbix_server_py/tests/test_trigger_eval.py
+++ b/zabbix_server_py/tests/test_trigger_eval.py
@@ -1,0 +1,13 @@
+from zabbix_server_py.cachehistory.cache import HistoryCache
+from zabbix_server_py.cachehistory.trigger import Trigger
+
+
+def test_trigger_evaluation():
+    cache = HistoryCache()
+    cache.add(1, 20)
+
+    trig = Trigger(1, "cache.get_last(1) > 10")
+    assert trig.evaluate(cache) is True
+
+    trig = Trigger(2, "cache.get_last(1) < 10")
+    assert trig.evaluate(cache) is False


### PR DESCRIPTION
## Summary
- port `cachehistory_server.c` and `trigger_eval.c` into a minimal Python module
- implement `HistoryCache` and `Trigger` classes
- add unit tests for caching and trigger evaluation

## Testing
- `pytest -q`