### PR TITLE
Add connector manager and worker modules

### DIFF
--- a/zabbix_server_py/__init__.py
+++ b/zabbix_server_py/__init__.py
@@ -1,1 +1,5 @@
 from .autoreg.autoreg_server import AutoRegServer
+from .connector.manager import ConnectorManager
+from .connector.worker import ConnectorWorker
+
+__all__ = ["AutoRegServer", "ConnectorManager", "ConnectorWorker"]

--- a/zabbix_server_py/connector/manager.py
+++ b/zabbix_server_py/connector/manager.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from typing import Any
+
+
+class ConnectorManager:
+    """Simplified connector manager.
+
+    This class is a minimal Python approximation of the
+    ``connector_manager_thread()`` function from the C implementation.
+    It listens for results from workers and stores them for inspection.
+    """
+
+    def __init__(self) -> None:
+        self.task_queue: queue.Queue[Any] = queue.Queue()
+        self.result_queue: queue.Queue[Any] = queue.Queue()
+        self.received_results: list[Any] = []
+        self.running = False
+
+    def add_request(self, data: Any) -> None:
+        """Send a request to connector workers."""
+        self.task_queue.put(data)
+
+    def run(self) -> None:
+        """Main manager loop.
+
+        Polls the result queue in a thread similar to
+        ``connector_manager_thread()``.
+        """
+        self.running = True
+        while self.running:
+            try:
+                result = self.result_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if result == "STOP":
+                self.running = False
+                continue
+            self.received_results.append(result)

--- a/zabbix_server_py/connector/worker.py
+++ b/zabbix_server_py/connector/worker.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import queue
+from typing import Any
+
+
+class ConnectorWorker:
+    """Simplified connector worker.
+
+    This class emulates ``zbx_connector_worker_thread()`` from the
+    original C code.  It reads requests from the manager queue and
+    places the processed results back.
+    """
+
+    def __init__(self, manager: "ConnectorManager") -> None:
+        self.manager = manager
+        self.running = False
+
+    def run(self) -> None:
+        """Worker processing loop.
+
+        Continually reads from :pyattr:`manager.task_queue` and writes results
+        into :pyattr:`manager.result_queue`.
+        """
+        self.running = True
+        while self.running:
+            try:
+                task: Any = self.manager.task_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if task == "STOP":
+                self.manager.result_queue.put("STOP")
+                self.running = False
+                continue
+            self.manager.result_queue.put(f"OK:{task}")

--- a/zabbix_server_py/tests/test_connector.py
+++ b/zabbix_server_py/tests/test_connector.py
@@ -1,0 +1,52 @@
+from threading import Thread
+import time
+
+from zabbix_server_py.connector.manager import ConnectorManager
+from zabbix_server_py.connector.worker import ConnectorWorker
+
+
+def test_worker_processes_request():
+    manager = ConnectorManager()
+    worker = ConnectorWorker(manager)
+
+    tm = Thread(target=manager.run, daemon=True)
+    tw = Thread(target=worker.run, daemon=True)
+    tm.start()
+    tw.start()
+
+    manager.add_request("ping")
+
+    for _ in range(20):
+        if "OK:ping" in manager.received_results:
+            break
+        time.sleep(0.1)
+
+    assert "OK:ping" in manager.received_results
+
+    manager.add_request("STOP")
+    tw.join(timeout=1)
+    tm.join(timeout=1)
+
+
+def test_multiple_requests():
+    manager = ConnectorManager()
+    worker = ConnectorWorker(manager)
+
+    tm = Thread(target=manager.run, daemon=True)
+    tw = Thread(target=worker.run, daemon=True)
+    tm.start()
+    tw.start()
+
+    for i in range(3):
+        manager.add_request(f"t{i}")
+
+    for _ in range(30):
+        if len(manager.received_results) >= 3:
+            break
+        time.sleep(0.1)
+
+    assert manager.received_results == ["OK:t0", "OK:t1", "OK:t2"]
+
+    manager.add_request("STOP")
+    tw.join(timeout=1)
+    tm.join(timeout=1)


### PR DESCRIPTION
## Summary
- add connector manager/worker modules
- export new classes in package
- test threaded connector simulation

## Testing
- `pytest -q zabbix_server_py/tests`