### PR TITLE
Add DBConfigServer skeleton with reload loop

### DIFF
--- a/zabbix_server_py/dbconfig/__init__.py
+++ b/zabbix_server_py/dbconfig/__init__.py
@@ -1,0 +1,5 @@
+"""Database configuration sync utilities."""
+
+from .server import DBConfigServer
+
+__all__ = ["DBConfigServer"]

--- a/zabbix_server_py/dbconfig/server.py
+++ b/zabbix_server_py/dbconfig/server.py
@@ -1,0 +1,56 @@
+"""Simplified configuration synchronisation loop."""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable
+
+
+def zbx_db_connect() -> None:
+    """Placeholder for the real database connection call."""
+    return None
+
+
+def zbx_dc_sync_configuration(reason: str) -> None:
+    """Placeholder for configuration sync."""
+    return None
+
+
+class DBConfigServer:
+    """Periodic configuration synchronisation thread."""
+
+    def __init__(self, interval: float = 10.0) -> None:
+        self.interval = interval
+        self._reload_event = threading.Event()
+        self._secrets_event = threading.Event()
+        self._stop_event = threading.Event()
+        self._wake_event = threading.Event()
+
+    # signal handlers -----------------------------------------------------
+    def request_reload(self) -> None:
+        self._reload_event.set()
+        self._wake_event.set()
+
+    def request_secrets_reload(self) -> None:
+        self._secrets_event.set()
+        self._wake_event.set()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._wake_event.set()
+
+    # main loop -----------------------------------------------------------
+    def run(self) -> None:
+        """Run until :py:meth:`stop` is called."""
+        zbx_db_connect()
+        while not self._stop_event.is_set():
+            if self._reload_event.is_set():
+                self._reload_event.clear()
+                zbx_dc_sync_configuration("reload")
+            elif self._secrets_event.is_set():
+                self._secrets_event.clear()
+                zbx_dc_sync_configuration("secrets")
+            else:
+                zbx_dc_sync_configuration("periodic")
+            self._wake_event.wait(self.interval)
+            self._wake_event.clear()

--- a/zabbix_server_py/tests/test_dbconfig_server.py
+++ b/zabbix_server_py/tests/test_dbconfig_server.py
@@ -1,0 +1,32 @@
+import threading
+import time
+
+from zabbix_server_py.dbconfig import server as dbserver
+from zabbix_server_py.dbconfig.server import DBConfigServer
+
+
+def test_reload_signal_wakes_loop(monkeypatch):
+    calls: list[str] = []
+
+    def fake_connect():
+        calls.append("connect")
+
+    def fake_sync(reason: str):
+        calls.append(reason)
+
+    monkeypatch.setattr(dbserver, "zbx_db_connect", fake_connect)
+    monkeypatch.setattr(dbserver, "zbx_dc_sync_configuration", fake_sync)
+
+    srv = DBConfigServer(interval=1.0)
+    t = threading.Thread(target=srv.run)
+    t.start()
+
+    # allow initial connect and sync
+    time.sleep(0.2)
+    srv.request_reload()
+    time.sleep(0.2)
+    srv.stop()
+    t.join(timeout=1)
+
+    assert "connect" in calls
+    assert "reload" in calls


### PR DESCRIPTION
## Summary
- implement simplified dbconfig server loop
- add reload handling test

## Testing
- `pytest -q zabbix_server_py/tests`