### PR TITLE
Add Escalator skeleton in Python

### DIFF
--- a/zabbix_server_py/__init__.py
+++ b/zabbix_server_py/__init__.py
@@ -1,5 +1,6 @@
 from .autoreg.autoreg_server import AutoRegServer
 from .connector.manager import ConnectorManager
 from .connector.worker import ConnectorWorker
+from .escalator.escalator import Escalator
 
-__all__ = ["AutoRegServer", "ConnectorManager", "ConnectorWorker"]
+__all__ = ["AutoRegServer", "ConnectorManager", "ConnectorWorker", "Escalator"]

--- a/zabbix_server_py/escalator/__init__.py
+++ b/zabbix_server_py/escalator/__init__.py
@@ -1,0 +1,5 @@
+"""Escalation processing for the Python rewrite."""
+
+from .escalator import Escalator
+
+__all__ = ["Escalator"]

--- a/zabbix_server_py/escalator/escalator.py
+++ b/zabbix_server_py/escalator/escalator.py
@@ -1,0 +1,51 @@
+"""Minimal escalator loop.
+
+This module provides a greatly simplified version of the logic
+implemented in ``escalator_thread`` from the original C source
+``src/zabbix_server/escalator/escalator.c``.  The real code processes
+pending escalations and generates alerts.  The Python variant merely
+invokes a placeholder check function at a configurable interval so that
+unit tests can verify the scheduling behaviour.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+class Escalator:
+    """Periodically execute escalation checks."""
+
+    def __init__(self, frequency: float = 1.0) -> None:
+        self.frequency = frequency
+        self.check_count = 0
+        self._running = False
+        self._lock = threading.Lock()
+
+    def _check_escalations(self) -> None:
+        """Placeholder for escalation processing."""
+        with self._lock:
+            self.check_count += 1
+
+    def stop(self) -> None:
+        """Request the main loop to exit."""
+        self._running = False
+
+    def run(self) -> None:
+        """Run the escalator loop.
+
+        This mirrors the behaviour of ``escalator_thread`` by
+        continually calling :py:meth:`_check_escalations` and sleeping
+        between iterations.  The loop exits when :py:meth:`stop` is
+        called.
+        """
+        self._running = True
+        while self._running:
+            start = time.time()
+            self._check_escalations()
+            elapsed = time.time() - start
+            sleep_time = self.frequency - elapsed
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+

--- a/zabbix_server_py/tests/test_escalator.py
+++ b/zabbix_server_py/tests/test_escalator.py
@@ -1,0 +1,30 @@
+from threading import Thread
+import time
+
+from zabbix_server_py.escalator.escalator import Escalator
+
+
+def test_escalator_runs_periodically():
+    esc = Escalator(frequency=0.1)
+    t = Thread(target=esc.run, daemon=True)
+    t.start()
+
+    time.sleep(0.35)
+    esc.stop()
+    t.join(timeout=1)
+
+    assert esc.check_count >= 3
+
+
+def test_escalator_stops():
+    esc = Escalator(frequency=0.1)
+    t = Thread(target=esc.run, daemon=True)
+    t.start()
+
+    time.sleep(0.15)
+    esc.stop()
+    count = esc.check_count
+    t.join(timeout=1)
+
+    time.sleep(0.2)
+    assert esc.check_count == count


### PR DESCRIPTION
## Summary
- implement `Escalator` in new `zabbix_server_py.escalator` package
- expose `Escalator` from package root
- provide tests verifying periodic checks and stopping

## Testing
- `pytest -q`