### PR TITLE
Add Python event handling module

### DIFF
--- a/zabbix_server_py/events/events.py
+++ b/zabbix_server_py/events/events.py
@@ -1,0 +1,162 @@
+"""Minimal event creation and recovery handling.
+
+This module implements a very small subset of ``src/zabbix_server/events/events.c``.
+Only the logic required for unit testing is provided.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from zabbix_server_py.actions import (
+    EVENT_OBJECT_TRIGGER,
+    EVENT_SOURCE_TRIGGERS,
+    TRIGGER_STATE_NORMAL,
+    TRIGGER_VALUE_OK,
+)
+
+# Additional constants ---------------------------------------------------------
+
+TRIGGER_VALUE_PROBLEM = 1
+
+FLAGS_RECALCULATE_PROBLEM_COUNT = 0x01
+
+
+@dataclass
+class Event:
+    """Simplified representation of ``zbx_db_event``."""
+
+    eventid: int
+    source: int
+    object: int
+    objectid: int
+    value: int
+    clock: int
+    name: str | None = None
+    flags: int = 0
+
+
+@dataclass
+class EventRecovery:
+    """Information about a recovered problem event."""
+
+    eventid: int
+    objectid: int
+    r_event: Event
+    correlationid: int = 0
+    c_eventid: int = 0
+    userid: int = 0
+    ts: int = 0
+
+
+@dataclass
+class TriggerDiff:
+    """Change set entry for a trigger."""
+
+    triggerid: int
+    priority: int
+    flags: int
+    value: int
+    state: int = TRIGGER_STATE_NORMAL
+
+
+_events: List[Event] = []
+_event_recovery: Dict[int, EventRecovery] = {}
+
+
+def reset() -> None:
+    """Clear internal storage used by the module."""
+
+    _events.clear()
+    _event_recovery.clear()
+
+
+def add_event(
+    source: int,
+    object: int,
+    objectid: int,
+    clock: int,
+    value: int,
+    name: str | None = None,
+) -> Event:
+    """Create and store an event."""
+
+    eventid = len(_events) + 1
+    event = Event(
+        eventid=eventid,
+        source=source,
+        object=object,
+        objectid=objectid,
+        value=value,
+        clock=clock,
+        name=name,
+        flags=0,
+    )
+    _events.append(event)
+    return event
+
+
+def close_trigger_event(
+    eventid: int,
+    objectid: int,
+    clock: int,
+    userid: int = 0,
+    correlationid: int = 0,
+    c_eventid: int = 0,
+    name: str | None = None,
+) -> Event:
+    """Create a recovery event and remember correlation information."""
+
+    r_event = add_event(
+        EVENT_SOURCE_TRIGGERS,
+        EVENT_OBJECT_TRIGGER,
+        objectid,
+        clock,
+        TRIGGER_VALUE_OK,
+        name,
+    )
+    recovery = EventRecovery(
+        eventid=eventid,
+        objectid=objectid,
+        r_event=r_event,
+        correlationid=correlationid,
+        c_eventid=c_eventid,
+        userid=userid,
+        ts=clock,
+    )
+    _event_recovery[eventid] = recovery
+    return r_event
+
+
+def append_trigger_diff(
+    diffs: Dict[int, TriggerDiff],
+    triggerid: int,
+    priority: int,
+    value: int,
+) -> TriggerDiff:
+    """Add or update a trigger diff entry using a dictionary."""
+
+    diff = diffs.get(triggerid)
+    if diff is None:
+        diff = TriggerDiff(
+            triggerid=triggerid,
+            priority=priority,
+            flags=FLAGS_RECALCULATE_PROBLEM_COUNT,
+            value=value,
+        )
+        diffs[triggerid] = diff
+    else:
+        diff.flags |= FLAGS_RECALCULATE_PROBLEM_COUNT
+    return diff
+
+
+def get_events() -> List[Event]:
+    """Return a copy of collected events."""
+
+    return list(_events)
+
+
+def get_event_recovery() -> Dict[int, EventRecovery]:
+    """Return a copy of recovery information."""
+
+    return dict(_event_recovery)

--- a/zabbix_server_py/tests/test_events.py
+++ b/zabbix_server_py/tests/test_events.py
@@ -1,0 +1,49 @@
+from zabbix_server_py.events.events import (
+    add_event,
+    append_trigger_diff,
+    close_trigger_event,
+    get_event_recovery,
+    get_events,
+    reset,
+    FLAGS_RECALCULATE_PROBLEM_COUNT,
+    TRIGGER_VALUE_PROBLEM,
+)
+from zabbix_server_py.actions import EVENT_SOURCE_TRIGGERS, EVENT_OBJECT_TRIGGER
+
+
+def setup_function(_func):
+    reset()
+
+
+def test_add_event():
+    event = add_event(
+        EVENT_SOURCE_TRIGGERS,
+        EVENT_OBJECT_TRIGGER,
+        1,
+        100,
+        TRIGGER_VALUE_PROBLEM,
+        name="problem",
+    )
+    events = get_events()
+    assert len(events) == 1
+    assert events[0] == event
+    assert event.objectid == 1
+
+
+def test_close_trigger_event_records_recovery():
+    ev = add_event(EVENT_SOURCE_TRIGGERS, EVENT_OBJECT_TRIGGER, 1, 100, TRIGGER_VALUE_PROBLEM)
+    ok_event = close_trigger_event(ev.eventid, 1, 200, userid=5)
+    events = get_events()
+    assert ok_event in events
+    rec = get_event_recovery()[ev.eventid]
+    assert rec.userid == 5
+    assert rec.r_event == ok_event
+
+
+def test_append_trigger_diff_uses_dict():
+    diffs = {}
+    append_trigger_diff(diffs, 10, priority=2, value=TRIGGER_VALUE_PROBLEM)
+    append_trigger_diff(diffs, 10, priority=2, value=TRIGGER_VALUE_PROBLEM)
+    assert len(diffs) == 1
+    diff = diffs[10]
+    assert diff.flags & FLAGS_RECALCULATE_PROBLEM_COUNT


### PR DESCRIPTION
## Summary
- implement `zabbix_server_py/events/events.py` providing simplified event creation and recovery logic
- store trigger diffs in a dictionary instead of a list
- validate event processing with new unit tests

## Testing
- `pytest -q`