### PR TITLE
Add operations processing module

### DIFF
--- a/zabbix_server_py/operations/operations.py
+++ b/zabbix_server_py/operations/operations.py
@@ -1,0 +1,41 @@
+"""Simplified action operation processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Dict
+
+
+# Supported operation types ----------------------------------------------------
+
+OPERATION_TYPE_MESSAGE = "message"
+OPERATION_TYPE_COMMAND = "command"
+
+
+@dataclass
+class Operation:
+    """Representation of a single action operation."""
+
+    type: str
+    params: Dict[str, Any] = field(default_factory=dict)
+
+
+def process_operations(
+    event: Any,
+    operations: List[Operation],
+    executor: Callable[[Operation, Any], None] | None = None,
+) -> None:
+    """Execute operations for *event*.
+
+    This is a very small subset of the logic implemented in the C
+    function ``process_operations`` from ``src/zabbix_server/operations/operations.c``.
+    The Python version merely validates operation types and invokes the
+    provided *executor* callback.
+    """
+
+    for op in operations:
+        if op.type not in (OPERATION_TYPE_MESSAGE, OPERATION_TYPE_COMMAND):
+            raise ValueError(f"unsupported operation type: {op.type}")
+
+        if executor is not None:
+            executor(op, event)

--- a/zabbix_server_py/tests/test_operations.py
+++ b/zabbix_server_py/tests/test_operations.py
@@ -1,0 +1,50 @@
+import pytest
+from zabbix_server_py.operations.operations import (
+    Operation,
+    OPERATION_TYPE_MESSAGE,
+    OPERATION_TYPE_COMMAND,
+    process_operations,
+)
+
+
+class DummyEvent:
+    def __init__(self, eventid: int) -> None:
+        self.eventid = eventid
+
+
+def test_process_operations_executes_all_operations():
+    event = DummyEvent(1)
+    ops = [
+        Operation(OPERATION_TYPE_MESSAGE, {"user": "u1", "text": "hi"}),
+        Operation(OPERATION_TYPE_COMMAND, {"cmd": "echo"}),
+    ]
+    calls: list[tuple[str, dict, int]] = []
+
+    def exec_op(op: Operation, ev: DummyEvent) -> None:
+        calls.append((op.type, op.params, ev.eventid))
+
+    process_operations(event, ops, exec_op)
+
+    assert calls == [
+        (OPERATION_TYPE_MESSAGE, {"user": "u1", "text": "hi"}, 1),
+        (OPERATION_TYPE_COMMAND, {"cmd": "echo"}, 1),
+    ]
+
+
+def test_process_operations_unknown_type():
+    event = DummyEvent(2)
+    ops = [Operation("bad", {})]
+
+    with pytest.raises(ValueError):
+        process_operations(event, ops)
+
+
+def test_process_operations_propagates_executor_error():
+    event = DummyEvent(3)
+    ops = [Operation(OPERATION_TYPE_MESSAGE, {})]
+
+    def boom(_op: Operation, _ev: DummyEvent) -> None:
+        raise RuntimeError("fail")
+
+    with pytest.raises(RuntimeError):
+        process_operations(event, ops, boom)


### PR DESCRIPTION
## Summary
- introduce `zabbix_server_py.operations.operations` implementing a minimal
  `process_operations` routine referencing the original C logic
- add unit tests for the new module

## Testing
- `pytest -q zabbix_server_py/tests/test_operations.py`
- `pytest -q zabbix_server_py/tests`