### PR TITLE
Add pgmanager cache and manager

### DIFF
--- a/zabbix_server_py/pgmanager/__init__.py
+++ b/zabbix_server_py/pgmanager/__init__.py
@@ -1,0 +1,13 @@
+"""Simplified proxy group manager components."""
+
+from .cache import Cache, Group, Proxy
+from .manager import PGManager
+from .service import PGService
+
+__all__ = [
+    "Cache",
+    "Group",
+    "Proxy",
+    "PGManager",
+    "PGService",
+]

--- a/zabbix_server_py/pgmanager/cache.py
+++ b/zabbix_server_py/pgmanager/cache.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Lightweight proxy group cache.
+
+This module is a very small subset of ``pg_cache.c``.
+It implements :func:`pg_cache_init`, :func:`pg_cache_update_groups` and
+:func:`pg_cache_update_proxies` in an in-memory form suitable for tests.
+"""
+
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Dict, List, Optional
+
+# state constants mirroring ``pg_cache.h`` ------------------------------
+PROXY_STATE_UNKNOWN = 0
+PROXY_STATE_OFFLINE = 1
+PROXY_STATE_ONLINE = 2
+
+GROUP_STATE_UNKNOWN = 0
+GROUP_STATE_OFFLINE = 1
+GROUP_STATE_RECOVERING = 2
+GROUP_STATE_ONLINE = 3
+GROUP_STATE_DEGRADING = 4
+GROUP_STATE_DISABLED = 5
+
+
+@dataclass
+class Proxy:
+    """Representation of a proxy."""
+
+    proxyid: int
+    groupid: Optional[int] = None
+    state: int = PROXY_STATE_UNKNOWN
+
+
+@dataclass
+class Group:
+    """Representation of a proxy group."""
+
+    groupid: int
+    state: int = GROUP_STATE_DISABLED
+    proxies: List[int] = field(default_factory=list)
+
+
+class Cache:
+    """In-memory cache.
+
+    Only the functionality required by unit tests is provided.  The
+    constructor loosely corresponds to ``pg_cache_init`` while the
+    :py:meth:`refresh` method combines ``pg_cache_update_groups`` and
+    ``pg_cache_update_proxies``.
+    """
+
+    def __init__(self) -> None:
+        self.proxies: Dict[int, Proxy] = {}
+        self.groups: Dict[int, Group] = {}
+        self.hostmap_revision = 0
+        self._lock = Lock()
+
+    def refresh(self, proxies: List[Proxy], groups: List[Group]) -> None:
+        """Replace cached data with *proxies* and *groups*.
+
+        Parameters follow the data loaded by ``pgm_update`` in the C
+        implementation.
+        """
+        with self._lock:
+            self.hostmap_revision += 1
+            self.proxies = {p.proxyid: p for p in proxies}
+            self.groups = {g.groupid: Group(g.groupid, g.state, []) for g in groups}
+            for proxy in proxies:
+                if proxy.groupid is not None and proxy.groupid in self.groups:
+                    self.groups[proxy.groupid].proxies.append(proxy.proxyid)
+
+    def get_group(self, groupid: int) -> Optional[Group]:
+        with self._lock:
+            return self.groups.get(groupid)
+
+    def get_proxy(self, proxyid: int) -> Optional[Proxy]:
+        with self._lock:
+            return self.proxies.get(proxyid)

--- a/zabbix_server_py/pgmanager/manager.py
+++ b/zabbix_server_py/pgmanager/manager.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Very small proxy group manager.
+
+This is a Python approximation of ``pg_manager_thread`` found in
+``pg_manager.c``. Only basic state management is implemented.
+"""
+
+import time
+from threading import Thread
+from typing import Optional
+
+from .cache import Cache
+
+
+class PGManager:
+    """Simplified manager running in a thread."""
+
+    STATE_INIT = 0
+    STATE_RUNNING = 1
+    STATE_STOPPED = 2
+
+    def __init__(self, cache: Cache | None = None) -> None:
+        self.cache = cache or Cache()
+        self.state = self.STATE_INIT
+        self.running = False
+        self._thread: Optional[Thread] = None
+
+    # public API ------------------------------------------------------------
+    def start(self) -> None:
+        self._thread = Thread(target=self.run, daemon=True)
+        self._thread.start()
+
+    def run(self) -> None:
+        """Manager loop.
+
+        Mirrors the structure of ``pg_manager_thread`` but omits all
+        database and IPC interactions.
+        """
+        self.state = self.STATE_RUNNING
+        self.running = True
+        while self.running:
+            time.sleep(0.05)
+        self.state = self.STATE_STOPPED
+
+    def stop(self) -> None:
+        self.running = False
+        if self._thread is not None:
+            self._thread.join(timeout=1)

--- a/zabbix_server_py/pgmanager/service.py
+++ b/zabbix_server_py/pgmanager/service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Utility helpers for proxy group manager service.
+
+These routines roughly correspond to parts of ``pg_service.c`` such as
+``pg_update_proxy_rtdata``.
+"""
+
+from .cache import Cache, PROXY_STATE_ONLINE, PROXY_STATE_OFFLINE
+
+
+class PGService:
+    """Very small service updating proxy runtime data."""
+
+    def __init__(self, cache: Cache) -> None:
+        self.cache = cache
+
+    def update_proxy_state(self, proxyid: int, online: bool) -> None:
+        """Set proxy state to online or offline.
+
+        This is a small subset of ``pg_update_proxy_rtdata``.
+        """
+        proxy = self.cache.get_proxy(proxyid)
+        if proxy is not None:
+            proxy.state = PROXY_STATE_ONLINE if online else PROXY_STATE_OFFLINE

--- a/zabbix_server_py/tests/test_pgmanager.py
+++ b/zabbix_server_py/tests/test_pgmanager.py
@@ -1,0 +1,40 @@
+from threading import Thread
+import time
+
+from zabbix_server_py.pgmanager.cache import (
+    Cache,
+    Group,
+    Proxy,
+)
+from zabbix_server_py.pgmanager.manager import PGManager
+
+
+def test_cache_refresh_replaces_content():
+    cache = Cache()
+
+    cache.refresh([Proxy(1, groupid=1)], [Group(1)])
+    assert cache.get_group(1).proxies == [1]
+
+    # refresh with completely new data
+    cache.refresh([Proxy(2, groupid=2)], [Group(2)])
+    assert cache.get_group(1) is None
+    assert cache.get_group(2).proxies == [2]
+    assert cache.hostmap_revision == 2
+
+
+def test_manager_state_transition():
+    cache = Cache()
+    manager = PGManager(cache)
+    t = Thread(target=manager.run, daemon=True)
+    t.start()
+
+    for _ in range(20):
+        if manager.state == PGManager.STATE_RUNNING:
+            break
+        time.sleep(0.05)
+
+    assert manager.state == PGManager.STATE_RUNNING
+
+    manager.stop()
+    t.join(timeout=1)
+    assert manager.state == PGManager.STATE_STOPPED


### PR DESCRIPTION
## Summary
- implement simplified pgmanager package
- convert cache refresh and manager loop from C code
- provide unit tests for cache and manager

## Testing
- `pytest -q`