### PR TITLE
Add Poller module and tests

### DIFF
--- a/zabbix_server_py/poller/__init__.py
+++ b/zabbix_server_py/poller/__init__.py
@@ -1,0 +1,41 @@
+"""Simplified poller thread."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Iterable
+
+from . import checks_internal
+
+
+class Poller:
+    """Periodically execute internal checks."""
+
+    def __init__(self, items: Iterable[str], frequency: float = 1.0) -> None:
+        self.items = list(items)
+        self.frequency = frequency
+        self.values: dict[str, Any] = {}
+        self.poll_count = 0
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def poll_once(self) -> None:
+        for key in self.items:
+            try:
+                self.values[key] = checks_internal.get_value_internal(key)
+            except ValueError:
+                self.values[key] = None
+        self.poll_count += 1
+
+    def run(self) -> None:
+        """Run until :py:meth:`stop` is called."""
+        while not self._stop_event.is_set():
+            start = time.time()
+            self.poll_once()
+            elapsed = time.time() - start
+            sleep_time = self.frequency - elapsed
+            if sleep_time > 0:
+                time.sleep(sleep_time)

--- a/zabbix_server_py/poller/checks_internal.py
+++ b/zabbix_server_py/poller/checks_internal.py
@@ -1,0 +1,83 @@
+"""Internal check helpers for the Poller."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Stubs replicating C functions from checks_internal_server.c
+# ---------------------------------------------------------------------------
+
+_TRIGGER_COUNT = 3
+_ITEM_COUNT = 7
+_ITEM_UNSUPPORTED_COUNT = 2
+
+
+@dataclass
+class PBMemInfo:
+    """Simplified proxy buffer memory information."""
+
+    mem_total: int = 0
+    mem_used: int = 0
+
+
+@dataclass
+class PBStateInfo:
+    """Simplified proxy buffer state information."""
+
+    state: int = 0
+    changes_num: int = 0
+
+
+def pb_get_mem_info() -> PBMemInfo:
+    """Return dummy proxy buffer memory statistics."""
+
+    return PBMemInfo()
+
+
+def pb_get_state_info() -> PBStateInfo:
+    """Return dummy proxy buffer state statistics."""
+
+    return PBStateInfo()
+
+
+# ---------------------------------------------------------------------------
+# Internal item processing
+# ---------------------------------------------------------------------------
+
+def _parse_key(key: str) -> Tuple[str, List[str]]:
+    if not key.startswith("zabbix[") or not key.endswith("]"):
+        raise ValueError(f"Invalid key format: {key}")
+    inner = key[len("zabbix[") : -1]
+    parts = [p for p in inner.split(",")]
+    if not parts:
+        raise ValueError("Empty internal check")
+    return parts[0], parts[1:]
+
+
+def get_value_internal(key: str) -> Any:
+    """Return a value for a simplified internal check."""
+
+    param1, params = _parse_key(key)
+
+    if param1 == "triggers":
+        if params:
+            raise ValueError("Invalid number of parameters")
+        return _TRIGGER_COUNT
+
+    if param1 == "host":
+        if len(params) != 2:
+            raise ValueError("Invalid number of parameters")
+        _host = params[0]
+        param3 = params[1]
+        if param3 == "items":
+            return _ITEM_COUNT
+        if param3 == "items_unsupported":
+            return _ITEM_UNSUPPORTED_COUNT
+        if param3 == "maintenance":
+            return 0
+        raise ValueError("Invalid third parameter")
+
+    raise ValueError(f"Unsupported internal check: {param1}")

--- a/zabbix_server_py/tests/test_poller.py
+++ b/zabbix_server_py/tests/test_poller.py
@@ -1,0 +1,21 @@
+from threading import Thread
+import time
+
+from zabbix_server_py.poller import Poller
+
+
+def test_poll_once_collects_values():
+    p = Poller(["zabbix[triggers]", "zabbix[host,,items]"])
+    p.poll_once()
+    assert p.values["zabbix[triggers]"] == 3
+    assert p.values["zabbix[host,,items]"] == 7
+
+
+def test_poller_runs_periodically():
+    p = Poller(["zabbix[triggers]"], frequency=0.1)
+    t = Thread(target=p.run, daemon=True)
+    t.start()
+    time.sleep(0.35)
+    p.stop()
+    t.join(timeout=1)
+    assert p.poll_count >= 3


### PR DESCRIPTION
## Summary
- implement simplified poller thread
- add internal check helpers modelled after `checks_internal_server.c`
- provide unit tests for poller loop and value retrieval

## Testing
- `pytest -q`