### PR TITLE
Add postinit task manager

### DIFF
--- a/zabbix_server_py/main.py
+++ b/zabbix_server_py/main.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from .config import load_config
+from .postinit import run_postinit_tasks
 
 DEFAULT_CONFIG = Path("/etc/zabbix/zabbix_server.conf")
 
@@ -45,6 +46,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.test_config:
         print("Validation successful")
         return 0
+
+    # run initialization routines mirrored from postinit.c
+    run_postinit_tasks()
 
     # TODO: initialization logic goes here
     print("Starting server...")

--- a/zabbix_server_py/postinit/__init__.py
+++ b/zabbix_server_py/postinit/__init__.py
@@ -1,0 +1,19 @@
+"""Post-initialization task manager."""
+
+from .postinit import (
+    UPDATE_EVENTNAMES,
+    COPY_NESTED_HOST_PROTOTYPES,
+    add_task,
+    run_postinit_tasks,
+    reset,
+    get_log,
+)
+
+__all__ = [
+    "UPDATE_EVENTNAMES",
+    "COPY_NESTED_HOST_PROTOTYPES",
+    "add_task",
+    "run_postinit_tasks",
+    "reset",
+    "get_log",
+]

--- a/zabbix_server_py/postinit/postinit.py
+++ b/zabbix_server_py/postinit/postinit.py
@@ -1,0 +1,69 @@
+"""Post-initialization routines translated from ``postinit.c``.
+
+This module provides a minimal implementation of post start-up tasks.
+It mirrors ``zbx_check_postinit_tasks()`` from
+``src/zabbix_server/postinit/postinit.c`` and related helper
+functions.  Each task is represented by a numeric constant taken from
+``include/zbxtasks.h`` and is executed sequentially after the main
+configuration is loaded.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List
+
+# Task type constants ---------------------------------------------------------
+
+UPDATE_EVENTNAMES = 5  # ZBX_TM_TASK_UPDATE_EVENTNAMES
+COPY_NESTED_HOST_PROTOTYPES = 10  # ZBX_TM_TASK_COPY_NESTED_HOST_PROTOTYPES
+
+
+_tasks: List[int] = []
+_log: List[str] = []
+
+
+def reset() -> None:
+    """Clear pending tasks and execution log."""
+    _tasks.clear()
+    _log.clear()
+
+
+def add_task(task_type: int) -> None:
+    """Queue a post-initialization task."""
+    _tasks.append(task_type)
+
+
+# individual task handlers ----------------------------------------------------
+
+def update_event_names() -> None:
+    """Placeholder for ``update_event_names`` in the C code."""
+    _log.append("update_event_names")
+
+
+def copy_nested_host_prototypes() -> None:
+    """Placeholder for ``copy_nested_host_prototypes`` in the C code."""
+    _log.append("copy_nested_host_prototypes")
+
+
+_HANDLERS: dict[int, Callable[[], None]] = {
+    UPDATE_EVENTNAMES: update_event_names,
+    COPY_NESTED_HOST_PROTOTYPES: copy_nested_host_prototypes,
+}
+
+
+def run_postinit_tasks() -> List[str]:
+    """Execute queued tasks in the order they were added.
+
+    Returns the execution log for inspection by tests.
+    """
+    for t in list(_tasks):
+        handler = _HANDLERS.get(t)
+        if handler is not None:
+            handler()
+    _tasks.clear()
+    return list(_log)
+
+
+def get_log() -> List[str]:
+    """Return a copy of the execution log."""
+    return list(_log)

--- a/zabbix_server_py/tests/test_postinit.py
+++ b/zabbix_server_py/tests/test_postinit.py
@@ -1,0 +1,37 @@
+from zabbix_server_py.postinit import (
+    UPDATE_EVENTNAMES,
+    COPY_NESTED_HOST_PROTOTYPES,
+    add_task,
+    run_postinit_tasks,
+    reset,
+    get_log,
+)
+from zabbix_server_py.main import main
+
+
+def setup_function(_func):
+    reset()
+
+
+def test_tasks_run_in_order():
+    add_task(UPDATE_EVENTNAMES)
+    add_task(COPY_NESTED_HOST_PROTOTYPES)
+    log = run_postinit_tasks()
+    assert log == ["update_event_names", "copy_nested_host_prototypes"]
+
+
+def test_postinit_called_after_config(monkeypatch):
+    calls = []
+
+    def fake_load(path):
+        calls.append("config")
+
+    def fake_run():
+        calls.append("postinit")
+
+    monkeypatch.setattr("zabbix_server_py.main.load_config", fake_load)
+    monkeypatch.setattr("zabbix_server_py.main.run_postinit_tasks", fake_run)
+
+    main(["-c", "conf"])
+
+    assert calls == ["config", "postinit"]


### PR DESCRIPTION
## Summary
- implement simplified post-initialization tasks module
- call the task runner after config load
- test execution order and integration with main

## Testing
- `pytest -q`