### PR TITLE
Fix PNG loops in scripts

### DIFF
--- a/misc/images/png_to_sql.sh
+++ b/misc/images/png_to_sql.sh
@@ -3,7 +3,7 @@
 # A script to generate SQL from PNG images
 # depends on hexdump and base64
 
-scriptdir="$(dirname $0)"
+scriptdir="$(dirname "$0")"
 pngdir="${1:-png_modern}"
 sqlbasedir="$scriptdir/../../database"
 imagefile="images.sql"
@@ -21,11 +21,9 @@ done
 echo "Generating SQL files"
 
 
-imagecount=$(ls $pngdir/*.png | wc -l)
-
-# TODO: this loop won't work with directory names, containing spaces
-# using 'find' here seems to be a bit excessive for now
-for imagefile in $pngdir/*.png; do
+imagecount=$(find "$pngdir" -name '*.png' | wc -l)
+# Use 'find' to correctly handle file names containing spaces
+find "$pngdir" -name '*.png' -print0 | while IFS= read -r -d '' imagefile; do
 	((imagesdone++))
 	imagename="$(basename "${imagefile%.png}")"
 	image_data=$(hexdump -ve '"" 1/1 "%02X"' "$imagefile")

--- a/misc/images/png_to_xml.sh
+++ b/misc/images/png_to_xml.sh
@@ -12,8 +12,9 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export version="1.0" date="'$(date "+%d.%m.%y")'" time="'$(date "+%H.%M")'">
   <images>' > "$outputfile"
 
-imagecount=$(ls $imagedir/*.png | wc -l)
-for imagefile in $imagedir/*.png; do
+imagecount=$(find "$imagedir" -name '*.png' | wc -l)
+# Use 'find' to correctly handle file names containing spaces
+find "$imagedir" -name '*.png' -print0 | while IFS= read -r -d '' imagefile; do
 	((imagesdone++))
 	echo "    <image>
       <name>$(basename "${imagefile%.png}")</name>


### PR DESCRIPTION
## Summary
- handle spaces in png_to_sql.sh
- handle spaces in png_to_xml.sh

## Testing
- `bash -n misc/images/png_to_sql.sh`
- `bash -n misc/images/png_to_xml.sh`
