### PR TITLE
Add ProxyPoller module and tests

### DIFF
--- a/zabbix_server_py/proxypoller/poller.py
+++ b/zabbix_server_py/proxypoller/poller.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Simplified proxy poller implementation."""
+
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class Proxy:
+    """Description of a proxy to poll."""
+
+    name: str
+    addr: str = "127.0.0.1"
+    port: int = 10051
+    lastaccess: float = 0.0
+    last_response: Optional[str] = None
+
+
+class ProxyPoller:
+    """Recreate the polling loop from ``proxypoller.c`` in Python."""
+
+    def __init__(
+        self,
+        proxies: Iterable[Proxy],
+        timeout: float = 1.0,
+        frequency: float = 1.0,
+    ) -> None:
+        self.proxies: List[Proxy] = list(proxies)
+        self.timeout = timeout
+        self.frequency = frequency
+        self._stop_event = threading.Event()
+
+    # public API ------------------------------------------------------------
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    # internal helpers ------------------------------------------------------
+    def _connect(self, proxy: Proxy) -> socket.socket:
+        s = socket.create_connection((proxy.addr, proxy.port), timeout=self.timeout)
+        return s
+
+    def _poll_proxy(self, proxy: Proxy) -> None:
+        try:
+            with self._connect(proxy) as s:
+                s.sendall(b"data")
+                data = s.recv(1024)
+                proxy.last_response = data.decode()
+                proxy.lastaccess = time.time()
+        except OSError:
+            proxy.last_response = None
+
+    # main loop -------------------------------------------------------------
+    def poll_once(self) -> None:
+        for proxy in self.proxies:
+            self._poll_proxy(proxy)
+
+    def run(self) -> None:
+        while not self._stop_event.is_set():
+            start = time.time()
+            self.poll_once()
+            elapsed = time.time() - start
+            sleep_time = self.frequency - elapsed
+            if sleep_time > 0:
+                time.sleep(sleep_time)

--- a/zabbix_server_py/tests/test_proxypoller.py
+++ b/zabbix_server_py/tests/test_proxypoller.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from threading import Thread
+import socket
+import time
+
+from zabbix_server_py.proxypoller.poller import Proxy, ProxyPoller
+
+
+class FakeProxyServer:
+    def __init__(self) -> None:
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.bind(("127.0.0.1", 0))
+        self.addr, self.port = self.sock.getsockname()
+        self.running = False
+        self.thread: Thread | None = None
+        self.connections = 0
+
+    def start(self) -> None:
+        self.sock.listen()
+        self.running = True
+        self.thread = Thread(target=self._run, daemon=True)
+        self.thread.start()
+
+    def _run(self) -> None:
+        while self.running:
+            try:
+                conn, _ = self.sock.accept()
+            except OSError:
+                break
+            with conn:
+                self.connections += 1
+                try:
+                    data = conn.recv(1024)
+                    if data:
+                        conn.sendall(b"OK")
+                finally:
+                    pass
+
+    def stop(self) -> None:
+        self.running = False
+        try:
+            socket.create_connection((self.addr, self.port), timeout=0.1).close()
+        except OSError:
+            pass
+        if self.thread is not None:
+            self.thread.join(timeout=1)
+        self.sock.close()
+
+
+def test_proxy_poller_receives_data():
+    server = FakeProxyServer()
+    server.start()
+    proxy = Proxy("p1", addr=server.addr, port=server.port)
+    poller = ProxyPoller([proxy], frequency=0.1, timeout=0.5)
+    t = Thread(target=poller.run, daemon=True)
+    t.start()
+
+    for _ in range(20):
+        if proxy.last_response == "OK":
+            break
+        time.sleep(0.1)
+
+    poller.stop()
+    t.join(timeout=1)
+    server.stop()
+
+    assert proxy.last_response == "OK"
+    assert proxy.lastaccess > 0
+
+
+def test_proxy_poller_handles_connection_error():
+    # allocate unused port
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    proxy = Proxy("p1", addr="127.0.0.1", port=port)
+    poller = ProxyPoller([proxy], frequency=0.1, timeout=0.1)
+    t = Thread(target=poller.run, daemon=True)
+    t.start()
+
+    time.sleep(0.3)
+
+    poller.stop()
+    t.join(timeout=1)
+
+    assert proxy.last_response is None
+    assert proxy.lastaccess == 0


### PR DESCRIPTION
## Summary
- add `proxypoller` package with `ProxyPoller` class to simulate proxy polling
- implement simple socket-based connection handling
- add tests exercising successful and failed proxy interaction

## Testing
- `pytest -k proxypoller -q`
- `pytest zabbix_server_py/tests/test_proxypoller.py -q`
