### PR TITLE
Add simplified reporter module

### DIFF
--- a/zabbix_server_py/reporter/__init__.py
+++ b/zabbix_server_py/reporter/__init__.py
@@ -1,0 +1,21 @@
+"""Reporter module ported from ``src/zabbix_server/reporter``."""
+
+from .manager import time_to_urlfield, get_report_range, get_report_name
+from .protocol import (
+    serialize_begin_report,
+    deserialize_begin_report,
+    serialize_response,
+    deserialize_response,
+)
+from .writer import fetch_report
+
+__all__ = [
+    "time_to_urlfield",
+    "get_report_range",
+    "get_report_name",
+    "serialize_begin_report",
+    "deserialize_begin_report",
+    "serialize_response",
+    "deserialize_response",
+    "fetch_report",
+]

--- a/zabbix_server_py/reporter/manager.py
+++ b/zabbix_server_py/reporter/manager.py
@@ -1,0 +1,67 @@
+"""Utilities modeled on functions from ``report_manager.c``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+__all__ = [
+    "time_to_urlfield",
+    "get_report_range",
+    "get_report_name",
+]
+
+
+def time_to_urlfield(dt: datetime) -> str:
+    """Return *dt* formatted for use in a URL query field.
+
+    Equivalent to ``rm_time_to_urlfield``.
+    """
+    return dt.strftime("%Y-%m-%d%%20%H%%3A%M%%3A%S")
+
+
+def _start_of_period(dt: datetime, period: int) -> datetime:
+    if period == 0:  # day
+        return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    if period == 1:  # week (start Monday)
+        dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        return dt - timedelta(days=dt.weekday())
+    if period == 2:  # month
+        return dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if period == 3:  # year
+        return dt.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    raise ValueError("invalid period")
+
+
+def get_report_range(report_time: int, period: int) -> tuple[datetime, datetime]:
+    """Calculate the start and end timestamps for a report.
+
+    Mirrors ``rm_get_report_range`` for the supported periods.  ``period``
+    is interpreted as 0=day, 1=week, 2=month, 3=year.
+    """
+    dt = datetime.fromtimestamp(report_time)
+    to = _start_of_period(dt, period)
+    if period == 0:
+        delta = timedelta(days=1)
+    elif period == 1:
+        delta = timedelta(weeks=1)
+    elif period == 2:
+        # subtract one month by going to day 1 of previous month
+        month = to.month - 1 or 12
+        year = to.year - 1 if to.month == 1 else to.year
+        delta = to - datetime(year, month, 1)
+    elif period == 3:
+        delta = timedelta(days=365)  # rough year
+    else:
+        raise ValueError("invalid period")
+    frm = to - delta
+    return frm, to
+
+
+def get_report_name(name: str, report_time: int) -> str:
+    """Return sanitized file name for report attachment.
+
+    Translates ``rm_get_report_name``.
+    """
+    safe = "".join("_" if c in " \t:/\\" else c for c in name)
+    dt = datetime.fromtimestamp(report_time)
+    return f"{safe}_{dt:%Y-%m-%d_%H-%M}.pdf"

--- a/zabbix_server_py/reporter/protocol.py
+++ b/zabbix_server_py/reporter/protocol.py
@@ -1,0 +1,94 @@
+"""Simple serialization helpers from ``report_protocol.c``."""
+
+from __future__ import annotations
+
+import struct
+from typing import Iterable, List, Tuple
+
+__all__ = [
+    "serialize_begin_report",
+    "deserialize_begin_report",
+    "serialize_response",
+    "deserialize_response",
+]
+
+
+# ---------------------------------------------------------------------------
+# Begin report message
+# ---------------------------------------------------------------------------
+
+def _pack_str(s: str) -> bytes:
+    data = s.encode()
+    return struct.pack("<I", len(data)) + data
+
+
+def _unpack_str(data: bytes, offset: int) -> Tuple[str, int]:
+    (length,) = struct.unpack_from("<I", data, offset)
+    offset += 4
+    s = data[offset : offset + length].decode()
+    offset += length
+    return s, offset
+
+
+def serialize_begin_report(
+    name: str, url: str, cookie: str, params: Iterable[Tuple[str, str]]
+) -> bytes:
+    """Serialize parameters as used in ``report_serialize_begin_report``."""
+    items = list(params)
+    payload = b"".join(_pack_str(p) + _pack_str(v) for p, v in items)
+    header = b"".join((_pack_str(name), _pack_str(url), _pack_str(cookie), struct.pack("<I", len(items))))
+    return header + payload
+
+
+def deserialize_begin_report(data: bytes) -> Tuple[str, str, str, List[Tuple[str, str]]]:
+    """Inverse of :func:`serialize_begin_report`."""
+    offset = 0
+    name, offset = _unpack_str(data, offset)
+    url, offset = _unpack_str(data, offset)
+    cookie, offset = _unpack_str(data, offset)
+    (num_params,) = struct.unpack_from("<I", data, offset)
+    offset += 4
+    params: List[Tuple[str, str]] = []
+    for _ in range(num_params):
+        key, offset = _unpack_str(data, offset)
+        val, offset = _unpack_str(data, offset)
+        params.append((key, val))
+    return name, url, cookie, params
+
+
+# ---------------------------------------------------------------------------
+# Response message
+# ---------------------------------------------------------------------------
+
+
+def serialize_response(status: int, error: str | None, results: Iterable[Tuple[int, str, str]]) -> bytes:
+    """Serialize a report result message.
+
+    Mirrors ``report_serialize_response`` but supports only the fields used in
+    the tests.
+    """
+    if error is None:
+        error = ""
+    results_list = list(results)
+    payload = struct.pack("<I", status) + _pack_str(error) + struct.pack("<I", len(results_list))
+    for st, rec, info in results_list:
+        payload += struct.pack("<I", st) + _pack_str(rec) + _pack_str(info)
+    return payload
+
+
+def deserialize_response(data: bytes) -> Tuple[int, str, List[Tuple[int, str, str]]]:
+    """Decode bytes produced by :func:`serialize_response`."""
+    offset = 0
+    (status,) = struct.unpack_from("<I", data, offset)
+    offset += 4
+    err, offset = _unpack_str(data, offset)
+    (count,) = struct.unpack_from("<I", data, offset)
+    offset += 4
+    results: List[Tuple[int, str, str]] = []
+    for _ in range(count):
+        (st,) = struct.unpack_from("<I", data, offset)
+        offset += 4
+        rec, offset = _unpack_str(data, offset)
+        info, offset = _unpack_str(data, offset)
+        results.append((st, rec, info))
+    return status, err, results

--- a/zabbix_server_py/reporter/writer.py
+++ b/zabbix_server_py/reporter/writer.py
@@ -1,0 +1,17 @@
+"""Lightweight report fetching utilities."""
+
+from __future__ import annotations
+
+__all__ = ["fetch_report"]
+
+
+def fetch_report(url: str, cookie: str, webservice_url: str | None = None) -> bytes:
+    """Return dummy PDF data from a URL.
+
+    This stands in for ``rw_get_report``.  The real implementation would make an
+    HTTP request using *webservice_url*, passing *cookie* for authentication.
+    The Python version simply returns a predictable PDF header for testing.
+    """
+    pdf_header = b"%PDF-1.4\n%Dummy\n"
+    meta = f"URL:{url}|COOKIE:{cookie}|WS:{webservice_url or ''}".encode()
+    return pdf_header + meta

--- a/zabbix_server_py/tests/test_reporter.py
+++ b/zabbix_server_py/tests/test_reporter.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+from zabbix_server_py.reporter import (
+    time_to_urlfield,
+    get_report_range,
+    get_report_name,
+    serialize_begin_report,
+    deserialize_begin_report,
+    serialize_response,
+    deserialize_response,
+    fetch_report,
+)
+
+
+def test_time_to_urlfield():
+    dt = datetime(2024, 1, 2, 3, 4, 5)
+    assert time_to_urlfield(dt) == "2024-01-02%2003%3A04%3A05"
+
+
+def test_get_report_name():
+    ts = int(datetime(2024, 1, 2, 3, 0).timestamp())
+    assert get_report_name("Report /name", ts) == "Report__name_2024-01-02_03-00.pdf"
+
+
+def test_get_report_range_week():
+    ts = int(datetime(2024, 1, 5, 12, 0).timestamp())
+    start, end = get_report_range(ts, 1)
+    assert start.weekday() == 0  # Monday
+    assert (end - start).days == 7
+
+
+def test_begin_report_roundtrip():
+    data = serialize_begin_report("r", "u", "c", [("p", "v")])
+    name, url, cookie, params = deserialize_begin_report(data)
+    assert name == "r" and url == "u" and cookie == "c"
+    assert params == [("p", "v")]
+
+
+def test_response_roundtrip():
+    res = [(1, "a", "b"), (0, "x", "y")]
+    data = serialize_response(0, "", res)
+    status, error, out = deserialize_response(data)
+    assert status == 0 and error == "" and out == res
+
+
+def test_fetch_report():
+    data = fetch_report("http://x", "sid", webservice_url="ws")
+    assert data.startswith(b"%PDF")
+    assert b"URL:http://x" in data
+    assert b"COOKIE:sid" in data
+


### PR DESCRIPTION
## Summary
- implement Python stubs for reporter manager utilities
- add basic message serialization helpers
- provide dummy report fetcher
- cover reporter helpers with tests

## Testing
- `pytest -q`